### PR TITLE
Add two functions that receive a lambda

### DIFF
--- a/media/src/main/java/com/google/modernstorage/media/MediaStoreClient.kt
+++ b/media/src/main/java/com/google/modernstorage/media/MediaStoreClient.kt
@@ -31,6 +31,12 @@ val UnopenableOutputStreamException = Exception("Output stream could not be open
 class MediaStoreClient(private val context: Context) {
     suspend fun getResourceByUri(uri: Uri) = getMediaResourceById(context, uri)
 
+    suspend inline fun withResourceByUri(uri: Uri, block: (MediaResource?) -> Unit) =
+        block.invoke(getResourceByUri(uri))
+
+    suspend inline fun withResourceByUriIfExist(uri: Uri, block: (MediaResource) -> Unit) =
+        getResourceByUri(uri)?.let(block)
+
     suspend fun createImageUri(filename: String, location: StorageLocation): Uri? {
         return withContext(Dispatchers.IO) {
             val entry = ContentValues().apply {

--- a/sample/src/main/java/com/google/modernstorage/sample/mediastore/MediaStoreViewModel.kt
+++ b/sample/src/main/java/com/google/modernstorage/sample/mediastore/MediaStoreViewModel.kt
@@ -65,7 +65,7 @@ class MediaStoreViewModel(
 
     fun setCurrentMedia(uri: Uri) {
         viewModelScope.launch {
-            mediaStore.getResourceByUri(uri)?.let {
+            mediaStore.withResourceByUriIfExist(uri) {
                 savedStateHandle.set("currentMediaUri", uri)
                 _currentMedia.value = mediaStore.getResourceByUri(uri)
             }


### PR DESCRIPTION
### Description
In many cases, we may use `getResourceByUri()` like this:

```kotlin
mediaStore.getResourceByUri(uri)?.let {
   // .. //
}

val mediaResource = mediaStore.getResourceByUri(uri)
if (mediaResource != null) {
  // .. //
 }
```
I think it could be a little bit more convenient with new functions instead of using scope functions every time.

### What's the difference?
Added two functions that receive a lambda that has a `MediaResource` as a receiver.

- withResourceByUri(uri: Uri, block: (MediaResource?) -> Unit)
- withResourceByUriIfExist(uri: Uri, block: (MediaResource) -> Unit)

#### Before
```kotlin
mediaStore.getResourceByUri(uri)?.let {
    savedStateHandle.set("currentMediaUri", uri)
    _currentMedia.value = mediaStore.getResourceByUri(uri)
}
```

#### After
```kotlin
mediaStore.withResourceByUri(uri) {
    savedStateHandle.set("currentMediaUri", uri)
    _currentMedia.value = mediaStore.getResourceByUri(uri)
}
```

I think the function names are not the best choices. So If have any better ideas, hope to give me feedback.
Thank you! 😃