### PR TITLE
Add filesystem writing example

### DIFF
--- a/docs/filesystem.md
+++ b/docs/filesystem.md
@@ -85,7 +85,7 @@ val path = AndroidPaths.get(documentUri)
 ```
 
 ## Get file size
-You can get the file size by using the method `Files.size`:
+You can get the file size by using the method [`Files.size`][Files.size_api]:
 
 ```kotlin
 val path = AndroidPaths.get(documentUri)
@@ -93,7 +93,8 @@ val size = Files.size(path)
 ```
 
 ## Get InputStream
-You can get an [InputStream][InputStream_api] of by using the method `Files.newInputStream`:
+You can get an [InputStream][InputStream_api] of by using the method
+[`Files.newInputStream`][Files.newInputStream_api]:
 
 ```kotlin
 val path = AndroidPaths.get(documentUri)
@@ -101,24 +102,31 @@ val inputStream = Files.newInputStream(path)
 ```
 
 ## Read a text file
-You can read a text file by using the method `Files.readAllLines`:
+You can read a text file by using the method [`Files.readAllLines`][Files.readAllLines_api]:
 
 ```kotlin
-/**
- * documentUri refers to a Uri your app has received using SAF
- */
 val path = AndroidPaths.get(documentUri)
 val content = Files.readAllLines(path).joinToString(separator = "\n")
 ```
 
-## Get a bitmap from an image
-Modifying a file requires to scan it to make MediaStore aware of the file changes (size,
-modification date, etc.). To request a scan for a media URI, use the `scanUri` method:
+## Write a ByteArray
+If you have write access to a document uri, you can write a `ByteArray` by using the method
+[`Files.write`][Files.write_api]:
 
 ```kotlin
 val path = AndroidPaths.get(documentUri)
-val inputStream = Files.newInputStream(path)
-val bitmap = BitmapFactory.decodeStream(inputStream)
+val bytes = byteArrayOf(75, 111, 116, 108, 105, 110)
+Files.write(path, bytes)
+```
+
+## Write from an InputStream
+You can get an [InputStream][InputStream_api] of by using the method `Files.newInputStream`:
+If you have write access to a document uri, you can write from an [InputStream][InputStream_api] by
+using the method [`Files.copy`][Files.copy_api]:
+
+```kotlin
+val path = AndroidPaths.get(documentUri)
+Files.copy(inputStream, path)
 ```
 
 [saf_guide]: https://developer.android.com/guide/topics/providers/document-provider
@@ -128,4 +136,9 @@ val bitmap = BitmapFactory.decodeStream(inputStream)
 [java.nio_api]: https://developer.android.com/reference/java/nio/package-summary
 [Uri_api]: https://developer.android.com/reference/kotlin/android/net/Uri
 [api_reference]: /api/filesystem
+[Files.size_api]: https://developer.android.com/reference/kotlin/java/nio/file/Files#size
+[Files.readAllLines_api]: https://developer.android.com/reference/kotlin/java/nio/file/Files#readalllines_1
 [InputStream_api]: https://developer.android.com/reference/kotlin/java/io/InputStream
+[Files.newInputStream_api]: https://developer.android.com/reference/kotlin/java/nio/file/Files#newinputstream
+[Files.write_api]: https://developer.android.com/reference/kotlin/java/nio/file/Files#write
+[Files.copy_api]: https://developer.android.com/reference/kotlin/java/nio/file/Files#copy_1

--- a/sample/src/main/java/com/google/modernstorage/sample/SampleData.kt
+++ b/sample/src/main/java/com/google/modernstorage/sample/SampleData.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.modernstorage.sample.mediastore
+package com.google.modernstorage.sample
 
 object SampleData {
     val image = listOf(
@@ -28,5 +28,11 @@ object SampleData {
         "https://storage.googleapis.com/android-tv/Sample%20videos/Demo%20Slam/Google%20Demo%20Slam_%20Dance%20Search.mp4",
         "https://storage.googleapis.com/android-tv/Sample%20videos/Demo%20Slam/Google%20Demo%20Slam_%20Extra%20Spicy.mp4",
         "https://storage.googleapis.com/android-tv/Sample%20videos/Demo%20Slam/Google%20Demo%20Slam_%20Get%20Your%20Money's%20Worth.mp4"
+    )
+
+    val texts = listOf(
+        "https://raw.githubusercontent.com/android/storage-samples/main/README.md",
+        "https://raw.githubusercontent.com/android/security-samples/main/README.md",
+        "https://raw.githubusercontent.com/google/modernstorage/main/README.md"
     )
 }

--- a/sample/src/main/java/com/google/modernstorage/sample/filesystem/FileSystemViewModel.kt
+++ b/sample/src/main/java/com/google/modernstorage/sample/filesystem/FileSystemViewModel.kt
@@ -111,10 +111,7 @@ class FileSystemViewModel(
 
                 response.body?.use { responseBody ->
                     @Suppress("BlockingMethodInNonBlockingContext")
-//                    Files.write(path, responseBody.bytes())
-                    Files.newOutputStream(path)?.use { outputStream ->
-                        responseBody.byteStream().copyTo(outputStream)
-                    }
+                    Files.copy(responseBody.byteStream(), path)
                 }
             }
 

--- a/sample/src/main/java/com/google/modernstorage/sample/filesystem/FileSystemViewModel.kt
+++ b/sample/src/main/java/com/google/modernstorage/sample/filesystem/FileSystemViewModel.kt
@@ -29,10 +29,13 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.google.modernstorage.filesystem.AndroidFileSystems
 import com.google.modernstorage.filesystem.AndroidPaths
+import com.google.modernstorage.sample.SampleData
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
+import okhttp3.OkHttpClient
+import okhttp3.Request
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -43,6 +46,8 @@ class FileSystemViewModel(
     application: Application,
     private val savedStateHandle: SavedStateHandle
 ) : AndroidViewModel(application) {
+    private val httpClient by lazy { OkHttpClient() }
+
     val currentFile: LiveData<FileResource> = savedStateHandle.getLiveData(CURRENT_DOCUMENT_KEY)
     private val _currentFileContent = MutableLiveData<FileContent>()
     val currentFileContent: LiveData<FileContent> = _currentFileContent
@@ -51,12 +56,12 @@ class FileSystemViewModel(
         AndroidFileSystems.initialize(application)
     }
 
-    @Suppress("BlockingMethodInNonBlockingContext")
-    fun onFileSelect(uri: Uri, type: FileType) {
+    fun previewFile(uri: Uri, type: FileType) {
         viewModelScope.launch {
             withContext(Dispatchers.IO) {
                 val path = AndroidPaths.get(uri)
-                val file = FileResource(uri, Files.size(path), FileType.TEXT)
+                @Suppress("BlockingMethodInNonBlockingContext")
+                val file = FileResource(uri, Files.size(path), type)
 
                 withContext(Dispatchers.Main) {
                     savedStateHandle.set(CURRENT_DOCUMENT_KEY, file)
@@ -70,22 +75,50 @@ class FileSystemViewModel(
         }
     }
 
-    @Suppress("BlockingMethodInNonBlockingContext")
     private suspend fun loadTextContent(path: Path) {
         withContext(Dispatchers.IO) {
+            @Suppress("BlockingMethodInNonBlockingContext")
             val text = Files.readAllLines(path).joinToString(separator = "\n")
 
             _currentFileContent.postValue(TextContent(text))
         }
     }
 
-    @Suppress("BlockingMethodInNonBlockingContext")
     private suspend fun loadImageContent(path: Path) {
         withContext(Dispatchers.IO) {
+            @Suppress("BlockingMethodInNonBlockingContext")
             val inputStream = Files.newInputStream(path)
             val bitmap = BitmapFactory.decodeStream(inputStream)
 
             _currentFileContent.postValue(BitmapContent(bitmap))
+        }
+    }
+
+    fun downloadAndSaveContent(documentUri: Uri, type: FileType) {
+        viewModelScope.launch {
+            val path = AndroidPaths.get(documentUri)
+
+            val url = when (type) {
+                FileType.TEXT -> SampleData.texts.random()
+                FileType.IMAGE -> SampleData.image.random()
+            }
+
+            val request = Request.Builder().url(url).build()
+
+            withContext(Dispatchers.IO) {
+                @Suppress("BlockingMethodInNonBlockingContext")
+                val response = httpClient.newCall(request).execute()
+
+                response.body?.use { responseBody ->
+                    @Suppress("BlockingMethodInNonBlockingContext")
+//                    Files.write(path, responseBody.bytes())
+                    Files.newOutputStream(path)?.use { outputStream ->
+                        responseBody.byteStream().copyTo(outputStream)
+                    }
+                }
+            }
+
+            previewFile(documentUri, type)
         }
     }
 }

--- a/sample/src/main/java/com/google/modernstorage/sample/mediastore/MediaStoreViewModel.kt
+++ b/sample/src/main/java/com/google/modernstorage/sample/mediastore/MediaStoreViewModel.kt
@@ -27,6 +27,7 @@ import com.google.modernstorage.mediastore.FileResource
 import com.google.modernstorage.mediastore.FileType
 import com.google.modernstorage.mediastore.MediaStoreRepository
 import com.google.modernstorage.mediastore.SharedPrimary
+import com.google.modernstorage.sample.SampleData
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext

--- a/sample/src/main/res/layout/fragment_filesystem.xml
+++ b/sample/src/main/res/layout/fragment_filesystem.xml
@@ -85,6 +85,12 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/filesystem_create_text_file_label" />
+
+        <Button
+            android:id="@+id/create_image_file"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/filesystem_create_image_file_label" />
     </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="filesystem_open_text_file_label">Open text file</string>
     <string name="filesystem_open_image_file_label">Open image file</string>
     <string name="filesystem_create_text_file_label">Create text file</string>
+    <string name="filesystem_create_image_file_label">Create image file</string>
     <string name="filesystem_not_available_yet">This functionality is not available yet</string>
     <string name="filesystem_size">File size: %1$s</string>
 </resources>


### PR DESCRIPTION
- [x] Add filesystem writing example
- [x] Add `java.nio` writing code snippets in guide
- [x] Blocked by the inability to access `WritableChannel` (see crash bug details below)

```
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.google.modernstorage.sample, PID: 24988
    java.nio.channels.NonWritableChannelException
        at sun.nio.ch.FileChannelImpl.write(FileChannelImpl.java:239)
        at java.nio.channels.Channels.writeFullyImpl(Channels.java:79)
        at java.nio.channels.Channels.writeFully(Channels.java:102)
        at java.nio.channels.Channels.access$000(Channels.java:62)
        at java.nio.channels.Channels$1.write(Channels.java:175)
        at java.nio.file.Files.copy(Files.java:2909)
        at java.nio.file.Files.copy(Files.java:3027)
        at com.google.modernstorage.sample.filesystem.FileSystemViewModel$downloadAndSaveContent$1$1.invokeSuspend(FileSystemViewModel.kt:114)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:738)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```