### PR TITLE
Upgrade AGP & move all dependencies to Version Catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,8 +23,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.1.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31")
+        classpath(libs.agp)
+        classpath(libs.kotlin.plugin)
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -32,11 +32,11 @@ buildscript {
 }
 
 plugins {
-    id("com.diffplug.spotless") version "5.12.5"
-    id("org.jetbrains.dokka") version "1.4.32"
-    id("me.tylerbwong.gradle.metalava") version "0.1.9" apply false
-    id("com.vanniktech.maven.publish") version "0.18.0" apply false
-    id("org.jetbrains.kotlin.plugin.parcelize") version "1.4.32" apply false
+    alias(libs.plugins.spotless)
+    alias(libs.plugins.dokka)
+    alias(libs.plugins.metalava) apply false
+    alias(libs.plugins.maven.publish) apply false
+    alias(libs.plugins.kotlin.parcelize) apply false
 }
 
 allprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,9 @@
 kotlin = "1.5.31"
 
 [libraries]
+agp = { module = "com.android.tools.build:gradle", version = "7.1.2" }
+kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+
 stdlib-jdk7 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk7", version.ref = "kotlin" }
 coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version = "1.5.2" }
 
@@ -10,3 +13,10 @@ glide = { module = "com.github.skydoves:landscapist-glide", version = "1.4.5" }
 
 junit = { module = "junit:junit", version = "4.13.2" }
 robolectric = { module = "org.robolectric:robolectric", version = "4.7.3" }
+
+[plugins]
+spotless = { id = "com.diffplug.spotless", version = "5.12.5" }
+dokka = { id = "org.jetbrains.dokka", version = "1.4.32" }
+metalava = { id = "me.tylerbwong.gradle.metalava", version = "0.1.9" }
+maven-publish = { id = "com.vanniktech.maven.publish", version = "0.18.0" }
+kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version = "1.4.32" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -19,4 +19,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-enableFeaturePreview("VERSION_CATALOGS")
 
 dependencyResolutionManagement {
     versionCatalogs {


### PR DESCRIPTION
Upgrades Gradle to 7.4 which makes Version Catalog stable 🎉

Also, moves dependencies and plugins which weren't previous able to go into Version Catalog into it