### PR TITLE
Update incorrect collection MIME type for saving files in AddMedia screen

### DIFF
--- a/sample/src/main/java/com/google/modernstorage/sample/mediastore/MediaStoreViewModel.kt
+++ b/sample/src/main/java/com/google/modernstorage/sample/mediastore/MediaStoreViewModel.kt
@@ -62,13 +62,13 @@ class MediaStoreViewModel(application: Application) : AndroidViewModel(applicati
                 MediaType.VIDEO -> {
                     extension = "mp4"
                     mimeType = "video/mp4"
-                    collection = MediaStore.Images.Media.getContentUri("external")
+                    collection = MediaStore.Video.Media.getContentUri("external")
                     directory = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES)
                 }
                 MediaType.AUDIO -> {
                     extension = "wav"
                     mimeType = "audio/x-wav"
-                    collection = MediaStore.Images.Media.getContentUri("external")
+                    collection = MediaStore.Audio.Media.getContentUri("external")
                     directory = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MUSIC)
                 }
             }


### PR DESCRIPTION
Fixed incorrect collection MIME types which is causing `IllegalArgumentException` while saving videos and audio files.